### PR TITLE
Upgrade actions/upload-artifact to v4 in CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       run: ./gradlew test
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: plugin-artifact
         path: build/distributions/*.zip
@@ -42,12 +42,8 @@ jobs:
     - name: Verify plugin
       run: ./gradlew runPluginVerifier
 
-    - name: Generate test reports
-      run: ./gradlew jacocoTestReport
-      if: success() || failure()  # Générer les rapports même en cas d'échec des tests
-
     - name: Archive test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: test-results
         path: build/reports/tests/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       run: ./gradlew runPluginVerifier
 
     - name: Upload plugin artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: api-generator-plugin
         path: build/distributions/*.zip


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use the latest version of the `actions/upload-artifact` action and removes a step for generating test reports in the CI workflow.

### Updates to GitHub Actions workflows:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL36-R36): Updated the `actions/upload-artifact` action from version `v3` to `v4` in the "Upload build artifacts" and "Archive test results" steps. Additionally, the "Generate test reports" step, which ran `./gradlew jacocoTestReport`, was removed. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL36-R36) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL45-R46)
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L46-R46): Updated the `actions/upload-artifact` action from version `v3` to `v4` in the "Upload plugin artifact" step.